### PR TITLE
fix: Remove extra '\' in path for vendor:publish example

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -35,7 +35,7 @@ composer require sprout/sprout
 Once you have Sprout installed, you'll want to publish the config.
 
 ```shell
-php artisan vendor:publish --provider="Sprout\\SproutServiceProvider"
+php artisan vendor:publish --provider="Sprout\SproutServiceProvider"
 ```
 
 ## Next Steps


### PR DESCRIPTION
The following is pasted as docs gave the publish command
```
PS C:\Users\joshu\Herd\TOPSECRET> php artisan vendor:publish --provider="Sprout\\SproutServiceProvider"
INFO  No publishable resources for tag [].
 ```
 However as you can see above the issue is due to a extra `\`
 Removing it publishes as expected. 
 
 ```
PS C:\Users\joshu\Herd\TOPSECRET> php artisan vendor:publish --provider="Sprout\SproutServiceProvider" 

INFO  Publishing assets.
```