### PR TITLE
fix: Update service provider path and references to bigInt()

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -143,12 +143,12 @@ If you plan to continue with this driver, you'll need to add two columns to the 
 
 ```php
 $table->string('tenancy')->nullable();
-$table->bigInt('tenant_id')->nullable();
+$table->unsignedBigIntegereger('tenant_id')->nullable();
 ```
 
 > [!NOTE]
 > The `tenant_id` column should match the primary key of your tenant model, which by default within Laravel would
-> be `BIGINT`, which is why `bigInt()` is used here.
+> be `BIGINT`, which is why `unsignedBigInteger()` is used here.
 
 The only other thing to consider here is that if you encounter CSRF issues when you first get started, clear your
 cookies in your browser, and it'll fix the issue.

--- a/installation.md
+++ b/installation.md
@@ -32,7 +32,7 @@ composer require sprout/sprout
 Sprout is configured to make use of Laravel's package auto-discovery, so its service provider should be automatically
 registered.
 If you have this disabled, it's not working for some reason, or you'd like to manually control where Sprout is loaded,
-you can manually register it in `bootstrap/app.php`, before your `AppServiceProvider`.
+you can manually register it in `bootstrap/providers.php`, before your `AppServiceProvider`.
 
 ```php
 return [

--- a/installation.md
+++ b/installation.md
@@ -143,7 +143,7 @@ If you plan to continue with this driver, you'll need to add two columns to the 
 
 ```php
 $table->string('tenancy')->nullable();
-$table->unsignedBigIntegereger('tenant_id')->nullable();
+$table->unsignedBigInteger('tenant_id')->nullable();
 ```
 
 > [!NOTE]

--- a/service-overrides.md
+++ b/service-overrides.md
@@ -277,7 +277,7 @@ to the `password_resets` table in the
 Schema::create('password_reset_tokens', function (Blueprint $table) {
     $table->string('email')->primary();
     $table->string('tenancy')->nullable();// [tl! ++]
-    $table->bigInt('tenant_id')->nullable();// [tl! ++]
+    $table->unsignedBigInteger('tenant_id')->nullable();// [tl! ++]
     $table->string('token');
     $table->timestamp('created_at')->nullable();
 });
@@ -285,7 +285,7 @@ Schema::create('password_reset_tokens', function (Blueprint $table) {
 
 > [!NOTE]
 > The `tenant_id` column should match the primary key of your tenant model, which by default within Laravel would
-> be `BIGINT`, which is why `bigInt()` is used here.
+> be `BIGINT`, which is why `unsignedBigInteger()` is used here.
 
 ### Cookie
 
@@ -344,7 +344,7 @@ to include the tenant-specific columns.
 Schema::create('sessions', function (Blueprint $table) {
     $table->string('id')->primary();
     $table->string('tenancy')->nullable();// [tl! ++]
-    $table->bigInt('tenant_id')->nullable();// [tl! ++]
+    $table->unsignedBigInteger('tenant_id')->nullable();// [tl! ++]
     $table->foreignId('user_id')->nullable()->index();
     $table->string('ip_address', 45)->nullable();
     $table->text('user_agent')->nullable();


### PR DESCRIPTION
Hi, a few minor updates...

* [`installation.md`](diffhunk://#diff-a0ab6b4c22ea1ad409f8e2271ae1c1220e49c6a2782afa92ff2462367cbb37f5L35-R35): Updated instructions to manually register Sprout's service provider in `bootstrap/providers.php` instead of `bootstrap/app.php`.
* [`installation.md`](diffhunk://#diff-a0ab6b4c22ea1ad409f8e2271ae1c1220e49c6a2782afa92ff2462367cbb37f5L146-R151): Changed the `tenant_id` column type in example migration code from `bigInt()` to `unsignedBigInteger()`.
* [`service-overrides.md`](diffhunk://#diff-110ed9c630e591308e74b6838d15921f6e242631144044411025686dc3c8730aL280-R288): Updated the `tenant_id` column type in the `password_reset_tokens` table schema from `bigInt()` to `unsignedBigInteger()`.
* [`service-overrides.md`](diffhunk://#diff-110ed9c630e591308e74b6838d15921f6e242631144044411025686dc3c8730aL347-R347): Updated the `tenant_id` column type in the `sessions` table schema from `bigInt()` to `unsignedBigInteger()`.